### PR TITLE
Disabling firework usage prevents interaction with chests, crafting tables, etc.

### DIFF
--- a/src/main/java/com/dashomi/preventer/modules/UseBlockModule.java
+++ b/src/main/java/com/dashomi/preventer/modules/UseBlockModule.java
@@ -4,6 +4,7 @@ import com.dashomi.preventer.PreventerClient;
 import net.minecraft.block.*;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.*;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
@@ -152,7 +153,7 @@ public class UseBlockModule {
                 }
             }
 
-            if (PreventerClient.config.preventRocketUse && !playerEntity.isSpectator()) {
+            if (PreventerClient.config.preventRocketUse && !playerEntity.isSpectator() && !canInteractWithBlock(targetBlockState)) {
                 if (!playerEntity.isFallFlying() && handItem instanceof FireworkRocketItem && playerEntity.world.isClient) {
                     ActionResult actionResult = targetBlockState.onUse(playerEntity.world, playerEntity, hand, blockHitResult);
                     if (actionResult.isAccepted()) return ActionResult.PASS;
@@ -189,5 +190,14 @@ public class UseBlockModule {
         }
 
         return ActionResult.PASS;
+    }
+
+    private static boolean canInteractWithBlock(BlockState block) {
+        return (
+            block.isIn(BlockTags.CANDLE_CAKES) ||
+            block.isOf(Blocks.CAKE) ||
+            block.isOf(Blocks.REPEATER) ||
+            block.isOf(Blocks.COMPARATOR)
+        );
     }
 }

--- a/src/main/java/com/dashomi/preventer/modules/UseBlockModule.java
+++ b/src/main/java/com/dashomi/preventer/modules/UseBlockModule.java
@@ -152,14 +152,14 @@ public class UseBlockModule {
             }
 
             if (PreventerClient.config.preventRocketUse && !playerEntity.isSpectator()) {
-                if (!playerEntity.isFallFlying()) {
-                    if (PreventerClient.config.rocketInOffhand && playerEntity.getOffHandStack().getItem() instanceof FireworkRocketItem) {
+                if (!playerEntity.isFallFlying() && handItem instanceof FireworkRocketItem) {
+                    if (PreventerClient.config.rocketInOffhand && Hand.OFF_HAND == hand) {
                         if (PreventerClient.config.preventRocketUse_msg) {
                             playerEntity.sendMessage(Text.translatable("config.preventer.preventRocketUse.text"), true);
                         }
                         return ActionResult.FAIL;
                     }
-                    if (PreventerClient.config.rocketInMainHand && playerEntity.getMainHandStack().getItem() instanceof FireworkRocketItem) {
+                    if (PreventerClient.config.rocketInMainHand && Hand.MAIN_HAND == hand) {
                         if (PreventerClient.config.preventRocketUse_msg) {
                             playerEntity.sendMessage(Text.translatable("config.preventer.preventRocketUse.text"), true);
                         }

--- a/src/main/java/com/dashomi/preventer/modules/UseBlockModule.java
+++ b/src/main/java/com/dashomi/preventer/modules/UseBlockModule.java
@@ -4,6 +4,7 @@ import com.dashomi.preventer.PreventerClient;
 import net.minecraft.block.*;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.*;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
@@ -17,7 +18,8 @@ import static net.minecraft.block.SweetBerryBushBlock.AGE;
 public class UseBlockModule {
     public static ActionResult checkBlockUse(PlayerEntity playerEntity, World world, Hand hand, BlockHitResult blockHitResult) {
         if (!PreventerClient.config.overrideKeyPressed) {
-            Block targetBlock = world.getBlockState(blockHitResult.getBlockPos()).getBlock();
+            BlockState targetBlockState = world.getBlockState(blockHitResult.getBlockPos());
+            Block targetBlock = targetBlockState.getBlock();
             Item handItem = playerEntity.getStackInHand(hand).getItem();
             if (PreventerClient.config.noStrip) {
                 if (handItem instanceof AxeItem) {
@@ -151,8 +153,9 @@ public class UseBlockModule {
                 }
             }
 
-            if (PreventerClient.config.preventRocketUse && !playerEntity.isSpectator()) {
+            if (PreventerClient.config.preventRocketUse && !playerEntity.isSpectator() && !canInteractWithBlock(targetBlockState)) {
                 if (!playerEntity.isFallFlying() && handItem instanceof FireworkRocketItem) {
+
                     if (PreventerClient.config.rocketInOffhand && Hand.OFF_HAND == hand) {
                         if (PreventerClient.config.preventRocketUse_msg) {
                             playerEntity.sendMessage(Text.translatable("config.preventer.preventRocketUse.text"), true);
@@ -185,5 +188,54 @@ public class UseBlockModule {
         }
 
         return ActionResult.PASS;
+    }
+
+    private static boolean canInteractWithBlock(BlockState state)
+    {
+        var block = state.getBlock();
+        return (
+            state.isIn(BlockTags.ANVIL) ||
+            state.isIn(BlockTags.BEDS) ||
+            state.isIn(BlockTags.BUTTONS) ||
+            state.isIn(BlockTags.DOORS) ||
+            state.isIn(BlockTags.TRAPDOORS) ||
+            state.isIn(BlockTags.SIGNS) ||
+            state.isIn(BlockTags.FENCE_GATES) ||
+            state.isIn(BlockTags.SHULKER_BOXES) ||
+            block == Blocks.BEACON ||
+            block == Blocks.BELL ||
+            block == Blocks.BREWING_STAND ||
+            block == Blocks.CARTOGRAPHY_TABLE ||
+            block == Blocks.CHEST ||
+            block == Blocks.TRAPPED_CHEST ||
+            block == Blocks.BARREL ||
+            block == Blocks.ENDER_CHEST ||
+            block == Blocks.COMMAND_BLOCK ||
+            block == Blocks.CHAIN_COMMAND_BLOCK ||
+            block == Blocks.REPEATING_COMMAND_BLOCK ||
+            block == Blocks.JIGSAW ||
+            block == Blocks.STRUCTURE_BLOCK ||
+            block == Blocks.CRAFTING_TABLE ||
+            block == Blocks.ENCHANTING_TABLE ||
+            block == Blocks.LECTERN ||
+            block == Blocks.LEVER ||
+            block == Blocks.LOOM ||
+            block == Blocks.NOTE_BLOCK ||
+            block == Blocks.JUKEBOX ||
+            block == Blocks.RESPAWN_ANCHOR ||
+            block == Blocks.SMITHING_TABLE ||
+            block == Blocks.FURNACE ||
+            block == Blocks.BLAST_FURNACE ||
+            block == Blocks.SMOKER ||
+            block == Blocks.REDSTONE_WIRE ||
+            block == Blocks.HOPPER ||
+            block == Blocks.DISPENSER ||
+            block == Blocks.DROPPER ||
+            block == Blocks.REPEATER ||
+            block == Blocks.COMPARATOR ||
+            block == Blocks.DAYLIGHT_DETECTOR ||
+            block == Blocks.REDSTONE_ORE ||
+            block == Blocks.STONECUTTER
+        );
     }
 }

--- a/src/main/java/com/dashomi/preventer/modules/UseBlockModule.java
+++ b/src/main/java/com/dashomi/preventer/modules/UseBlockModule.java
@@ -4,7 +4,6 @@ import com.dashomi.preventer.PreventerClient;
 import net.minecraft.block.*;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.*;
-import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
@@ -153,8 +152,10 @@ public class UseBlockModule {
                 }
             }
 
-            if (PreventerClient.config.preventRocketUse && !playerEntity.isSpectator() && !canInteractWithBlock(targetBlockState)) {
-                if (!playerEntity.isFallFlying() && handItem instanceof FireworkRocketItem) {
+            if (PreventerClient.config.preventRocketUse && !playerEntity.isSpectator()) {
+                if (!playerEntity.isFallFlying() && handItem instanceof FireworkRocketItem && playerEntity.world.isClient) {
+                    ActionResult actionResult = targetBlockState.onUse(playerEntity.world, playerEntity, hand, blockHitResult);
+                    if (actionResult.isAccepted()) return ActionResult.PASS;
 
                     if (PreventerClient.config.rocketInOffhand && Hand.OFF_HAND == hand) {
                         if (PreventerClient.config.preventRocketUse_msg) {
@@ -188,57 +189,5 @@ public class UseBlockModule {
         }
 
         return ActionResult.PASS;
-    }
-
-    private static boolean canInteractWithBlock(BlockState state)
-    {
-        var block = state.getBlock();
-        return (
-            state.isIn(BlockTags.ANVIL) ||
-            state.isIn(BlockTags.BEDS) ||
-            state.isIn(BlockTags.BUTTONS) ||
-            state.isIn(BlockTags.DOORS) ||
-            state.isIn(BlockTags.TRAPDOORS) ||
-            state.isIn(BlockTags.SIGNS) ||
-            state.isIn(BlockTags.FENCE_GATES) ||
-            state.isIn(BlockTags.SHULKER_BOXES) ||
-            state.isIn(BlockTags.CANDLE_CAKES) ||
-            block == Blocks.BEACON ||
-            block == Blocks.BELL ||
-            block == Blocks.BREWING_STAND ||
-            block == Blocks.CAKE ||
-            block == Blocks.CARTOGRAPHY_TABLE ||
-            block == Blocks.CHEST ||
-            block == Blocks.TRAPPED_CHEST ||
-            block == Blocks.BARREL ||
-            block == Blocks.ENDER_CHEST ||
-            block == Blocks.COMMAND_BLOCK ||
-            block == Blocks.CHAIN_COMMAND_BLOCK ||
-            block == Blocks.REPEATING_COMMAND_BLOCK ||
-            block == Blocks.JIGSAW ||
-            block == Blocks.STRUCTURE_BLOCK ||
-            block == Blocks.CRAFTING_TABLE ||
-            block == Blocks.ENCHANTING_TABLE ||
-            block == Blocks.LECTERN ||
-            block == Blocks.GRINDSTONE ||
-            block == Blocks.LEVER ||
-            block == Blocks.LOOM ||
-            block == Blocks.NOTE_BLOCK ||
-            block == Blocks.JUKEBOX ||
-            block == Blocks.RESPAWN_ANCHOR ||
-            block == Blocks.SMITHING_TABLE ||
-            block == Blocks.FURNACE ||
-            block == Blocks.BLAST_FURNACE ||
-            block == Blocks.SMOKER ||
-            block == Blocks.REDSTONE_WIRE ||
-            block == Blocks.HOPPER ||
-            block == Blocks.DISPENSER ||
-            block == Blocks.DROPPER ||
-            block == Blocks.REPEATER ||
-            block == Blocks.COMPARATOR ||
-            block == Blocks.DAYLIGHT_DETECTOR ||
-            block == Blocks.REDSTONE_ORE ||
-            block == Blocks.STONECUTTER
-        );
     }
 }

--- a/src/main/java/com/dashomi/preventer/modules/UseBlockModule.java
+++ b/src/main/java/com/dashomi/preventer/modules/UseBlockModule.java
@@ -202,9 +202,11 @@ public class UseBlockModule {
             state.isIn(BlockTags.SIGNS) ||
             state.isIn(BlockTags.FENCE_GATES) ||
             state.isIn(BlockTags.SHULKER_BOXES) ||
+            state.isIn(BlockTags.CANDLE_CAKES) ||
             block == Blocks.BEACON ||
             block == Blocks.BELL ||
             block == Blocks.BREWING_STAND ||
+            block == Blocks.CAKE ||
             block == Blocks.CARTOGRAPHY_TABLE ||
             block == Blocks.CHEST ||
             block == Blocks.TRAPPED_CHEST ||
@@ -218,6 +220,7 @@ public class UseBlockModule {
             block == Blocks.CRAFTING_TABLE ||
             block == Blocks.ENCHANTING_TABLE ||
             block == Blocks.LECTERN ||
+            block == Blocks.GRINDSTONE ||
             block == Blocks.LEVER ||
             block == Blocks.LOOM ||
             block == Blocks.NOTE_BLOCK ||


### PR DESCRIPTION
Noticed that if I hold rockets in my off hand and try to interact with any block it seems to be prevented if rocket usage is disabled.

This PR changes the prevent rocket use setting to check the current hand and item in that hand before disabling interacting with the block.