### PR TITLE
[Modtoberfest] Prevent Placing Blocks After Eating

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Each module can be enabled or disabled individually in game via a config screen 
   - _Prevents you from placing blocks in your off-hand_
 - Prevent berrie planting
   - _Prevents you from planting berries while trying to eat them (Sweet Berries & Glow Berries)_
+- Prevent block placing temporary after eating
+  - _Temporary prevents you from accidentally placing blocks after eating food_
 
 </details>
 

--- a/src/main/java/com/dashomi/preventer/PreventerClient.java
+++ b/src/main/java/com/dashomi/preventer/PreventerClient.java
@@ -7,12 +7,10 @@ import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
-import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
-import net.fabricmc.fabric.api.event.player.AttackEntityCallback;
-import net.fabricmc.fabric.api.event.player.UseBlockCallback;
-import net.fabricmc.fabric.api.event.player.UseItemCallback;
-import net.fabricmc.fabric.api.event.player.UseEntityCallback;
+
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +20,7 @@ public class PreventerClient implements ClientModInitializer {
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
     public static PreventerConfig config;
     public static boolean overrideKeyPressed = false;
+    public static int ticksSinceEating = 0;
 
     @Override
     public void onInitializeClient() {
@@ -34,6 +33,8 @@ public class PreventerClient implements ClientModInitializer {
         UseBlockCallback.EVENT.register(UseBlockEvent::useBlockListener);
         UseItemCallback.EVENT.register(UseItemEvent::useItemListener);
         UseEntityCallback.EVENT.register(UseEntityEvent::useEntityListener);
+
+        ClientTickEvents.END_WORLD_TICK.register(world -> ticksSinceEating++);
 
         RegisterKeyBindings.register();
     }

--- a/src/main/java/com/dashomi/preventer/PreventerClient.java
+++ b/src/main/java/com/dashomi/preventer/PreventerClient.java
@@ -9,8 +9,11 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
-
-
+import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.fabricmc.fabric.api.event.player.AttackEntityCallback;
+import net.fabricmc.fabric.api.event.player.UseBlockCallback;
+import net.fabricmc.fabric.api.event.player.UseItemCallback;
+import net.fabricmc.fabric.api.event.player.UseEntityCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/dashomi/preventer/config/CreateModConfig.java
+++ b/src/main/java/com/dashomi/preventer/config/CreateModConfig.java
@@ -339,6 +339,14 @@ public class  CreateModConfig {
                         .setSaveConsumer(value -> config.preventBerriePlanting = value)
                         .build())
 
+                .addEntry(entryBuilder.startBooleanToggle(
+                                Text.translatable("option.preventer.preventPlaceAfterEating"),
+                                config.preventPlaceAfterEating)
+                        .setDefaultValue(false)
+                        .setTooltip(Text.translatable("tooltip.preventer.preventPlaceAfterEating"))
+                        .setSaveConsumer(value -> config.preventPlaceAfterEating = value)
+                        .build())
+
                 // Attacking
                 .addEntry(entryBuilder.startTextDescription(
                                 Text.translatable("text.preventer.AttackingCategory"))
@@ -527,6 +535,30 @@ public class  CreateModConfig {
                         .setDefaultValue(false)
                         .setTooltip(Text.translatable("tooltip.preventer.preventChestSignEditing"))
                         .setSaveConsumer(value -> config.preventChestSignEditing = value)
+                        .build())
+
+                .addEntry(entryBuilder.startIntSlider(
+                                Text.translatable("option.preventer.afterEatingPreventionTicks"),
+                                config.afterEatingPreventionTicks, 1, 60)
+                        .setDefaultValue(15)
+                        .setTooltip(Text.translatable("tooltip.preventer.afterEatingPreventionTicks"))
+                        .setSaveConsumer(value -> config.afterEatingPreventionTicks = value)
+                        .build())
+
+                .addEntry(entryBuilder.startBooleanToggle(
+                                Text.translatable("option.preventer.preventTorchPlaceAfterEating"),
+                                config.preventTorchPlaceAfterEating)
+                        .setDefaultValue(false)
+                        .setTooltip(Text.translatable("tooltip.preventer.preventTorchPlaceAfterEating"))
+                        .setSaveConsumer(value -> config.preventTorchPlaceAfterEating = value)
+                        .build())
+
+                .addEntry(entryBuilder.startBooleanToggle(
+                                Text.translatable("option.preventer.countLanternsAsTorches"),
+                                config.countLanternsAsTorches)
+                        .setDefaultValue(false)
+                        .setTooltip(Text.translatable("tooltip.preventer.countLanternsAsTorches"))
+                        .setSaveConsumer(value -> config.countLanternsAsTorches = value)
                         .build());
 
 
@@ -819,6 +851,13 @@ public class  CreateModConfig {
                                 config.preventBerriePlanting_msg)
                         .setDefaultValue(false)
                         .setSaveConsumer(value -> config.preventBerriePlanting_msg = value)
+                        .build())
+
+                .addEntry(entryBuilder.startBooleanToggle(
+                                Text.translatable("option.preventer.preventPlaceAfterEating"),
+                                config.preventPlaceAfterEating_msg)
+                        .setDefaultValue(false)
+                        .setSaveConsumer(value -> config.preventPlaceAfterEating_msg = value)
                         .build())
 
                 // Attacking

--- a/src/main/java/com/dashomi/preventer/config/PreventerConfig.java
+++ b/src/main/java/com/dashomi/preventer/config/PreventerConfig.java
@@ -106,6 +106,11 @@ public class PreventerConfig implements ConfigData {
     public boolean preventOffhandPlacing_msg = false;
     public boolean preventBerriePlanting = false;
     public boolean preventBerriePlanting_msg = false;
+    public boolean preventPlaceAfterEating = false;
+    public boolean preventPlaceAfterEating_msg = false;
+    public int afterEatingPreventionTicks = 10;
+    public boolean preventTorchPlaceAfterEating = false;
+    public boolean countLanternsAsTorches = false;
 
     // Attacking
     public boolean preventVillagerPunch = false;

--- a/src/main/java/com/dashomi/preventer/listeners/PlayerJoinEvent.java
+++ b/src/main/java/com/dashomi/preventer/listeners/PlayerJoinEvent.java
@@ -15,5 +15,7 @@ public class PlayerJoinEvent {
             PreventerClient.config.welcomeMessage = false;
             PreventerConfig.save();
         }
+
+        PreventerClient.ticksSinceEating = 0;
     }
 }

--- a/src/main/java/com/dashomi/preventer/listeners/UseBlockEvent.java
+++ b/src/main/java/com/dashomi/preventer/listeners/UseBlockEvent.java
@@ -7,6 +7,7 @@ import net.minecraft.item.*;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.world.World;
@@ -255,6 +256,34 @@ public class UseBlockEvent {
                             playerEntity.sendMessage(Text.translatable("config.preventer.preventOffhandPlacing.text"), true);
                         }
                         return ActionResult.FAIL;
+                    }
+                }
+            }
+
+            if (PreventerClient.config.preventPlaceAfterEating) {
+                if (PreventerClient.ticksSinceEating <= PreventerClient.config.afterEatingPreventionTicks) {
+                    if (handItem instanceof BlockItem && canNotInteractWithBlock(targetBlockState, playerEntity, hand, blockHitResult)) {
+
+                        if (!PreventerClient.config.preventTorchPlaceAfterEating) {
+                            if (PreventerClient.config.preventPlaceAfterEating_msg) {
+                                playerEntity.sendMessage(Text.translatable("config.preventer.preventPlaceAfterEating.text"), true);
+                            }
+                            return ActionResult.FAIL;
+                        } else {
+                            boolean holdingTorch = handItem.equals(Items.TORCH);
+                            Text heldBlockName = Text.translatable("block.minecraft.torch").formatted(Formatting.DARK_RED);
+                            if (PreventerClient.config.countLanternsAsTorches && !holdingTorch) { //skipped if already holding torch
+                                holdingTorch = handItem.equals(Items.LANTERN);
+                                heldBlockName = Text.translatable("block.minecraft.lantern").formatted(Formatting.DARK_RED); //fun subtle detail :)
+                            }
+                            if (holdingTorch) {
+                                if (PreventerClient.config.preventPlaceAfterEating_msg) {
+                                    playerEntity.sendMessage(Text.translatable("config.preventer.preventTorchPlaceAfterEating.text", heldBlockName), true);
+                                }
+                                return ActionResult.FAIL;
+                            }
+                        }
+
                     }
                 }
             }

--- a/src/main/java/com/dashomi/preventer/listeners/UseItemEvent.java
+++ b/src/main/java/com/dashomi/preventer/listeners/UseItemEvent.java
@@ -4,8 +4,8 @@ import com.dashomi.preventer.PreventerClient;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
@@ -20,6 +20,15 @@ public class UseItemEvent {
                             player.sendMessage(Text.translatable("config.preventer.preventRenamedItemUsing.text"), true);
                         }
                         return TypedActionResult.fail(player.getStackInHand(hand));
+                    }
+                }
+            }
+
+            if (PreventerClient.config.preventPlaceAfterEating) {
+                if (player.getStackInHand(hand).get(DataComponentTypes.FOOD) != null ) {
+                    //confirms the player is actually eating the food and not just right-clicked the food on full hunger
+                    if (player.getStackInHand(hand).use(world, player, hand).getResult() == ActionResult.CONSUME) {
+                        PreventerClient.ticksSinceEating = 0;
                     }
                 }
             }

--- a/src/main/java/com/dashomi/preventer/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/dashomi/preventer/mixin/LivingEntityMixin.java
@@ -1,6 +1,7 @@
 package com.dashomi.preventer.mixin;
 
 import com.dashomi.preventer.PreventerClient;
+import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.component.type.FoodComponent;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
@@ -15,6 +16,10 @@ public class LivingEntityMixin {
 
     @Inject(method = "eatFood", at = @At(value = "TAIL"))
     private void resetTicksSinceFoodEat(World world, ItemStack stack, FoodComponent foodComponent, CallbackInfoReturnable<ItemStack> cir) {
-        PreventerClient.ticksSinceEating = 0;
+        LivingEntity entity = (LivingEntity) (Object) this;
+        //ensures the entity here is the client player
+        if (entity instanceof ClientPlayerEntity) {
+            PreventerClient.ticksSinceEating = 0;
+        }
     }
 }

--- a/src/main/java/com/dashomi/preventer/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/dashomi/preventer/mixin/LivingEntityMixin.java
@@ -1,0 +1,20 @@
+package com.dashomi.preventer.mixin;
+
+import com.dashomi.preventer.PreventerClient;
+import net.minecraft.component.type.FoodComponent;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(LivingEntity.class)
+public class LivingEntityMixin {
+
+    @Inject(method = "eatFood", at = @At(value = "TAIL"))
+    private void resetTicksSinceFoodEat(World world, ItemStack stack, FoodComponent foodComponent, CallbackInfoReturnable<ItemStack> cir) {
+        PreventerClient.ticksSinceEating = 0;
+    }
+}

--- a/src/main/resources/assets/preventer/lang/en_us.json
+++ b/src/main/resources/assets/preventer/lang/en_us.json
@@ -221,6 +221,17 @@
   "tooltip.preventer.preventBerriePlanting": "Prevents you from planting berries while trying to eat them (Sweet Berries & Glow Berries)",
   "config.preventer.preventBerriePlanting.text": "§4Berrie planting prevented§4",
 
+  "option.preventer.preventPlaceAfterEating": "Prevent placing after eating",
+  "tooltip.preventer.preventPlaceAfterEating": "Temporary prevents you from placing blocks after eating a food item.",
+  "config.preventer.preventPlaceAfterEating.text": "§4After eating block placing prevented§4",
+  "option.preventer.afterEatingPreventionTicks": "Prevention ticks after eating",
+  "tooltip.preventer.afterEatingPreventionTicks": "The amount of ticks to prevent block placement after starting to eat a food item and after finishing eating a food item.",
+  "option.preventer.preventTorchPlaceAfterEating": "Prevent torch placing after eating",
+  "tooltip.preventer.preventTorchPlaceAfterEating": "Temporary prevents you only from placing torches after eating a food item. \nDoes not include torch variants such as redstone torches and soul torches.",
+  "config.preventer.preventTorchPlaceAfterEating.text": "§4After eating§4 %1$s §4placing prevented§4",
+  "option.preventer.countLanternsAsTorches": "Consider lanterns as torches",
+  "tooltip.preventer.countLanternsAsTorches": "If enabled, lanterns are treated as torches for preventing torch placing after eating. \nDoes not include the soul lantern variant.",
+
   "option.preventer.preventDolphinAttacking": "Prevent dolphin attacking",
   "tooltip.preventer.preventDolphinAttacking": "Prevents you from attacking dolphins",
   "config.preventer.preventDolphinAttacking.text": "§4Dolphin attacking prevented§4",

--- a/src/main/resources/preventer.mixins.json
+++ b/src/main/resources/preventer.mixins.json
@@ -3,10 +3,12 @@
   "minVersion": "0.8",
   "package": "com.dashomi.preventer.mixin",
   "compatibilityLevel": "JAVA_17",
-  "mixins": [],
+  "mixins": [
+    "LivingEntityMixin"
+  ],
   "client": [
-    "RenderHandItemMixin",
-    "ClientPlayerEntityMixin"
+    "ClientPlayerEntityMixin",
+    "RenderHandItemMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Prevents you from placing blocks a configurable amount of ticks after eating food. Additionally, you can also change it to only prevent placing torches and lanterns after eating. Figured the lanterns would be fun because I can see myself using it. Fixes #79 (an issue I didn't realize existed until I already finished the code lol)

The `ticksSinceEating` variable gets reset after beginning to eat food and after finishing eating food. You can easily remove either in case you have a preference, but I figured players would expect both possibly without realizing it. It also gets reset on a player world join, just in case.

I've also allowed for the amount of ticks to prevent the block place to be configurable, as I figured some players would have different preferences depending on what they are doing(cave exploring vs daytime house building would probably want different times).

Here is a video showing the vanilla behavior

https://github.com/user-attachments/assets/6c7c5473-1d2d-4eaa-b71c-edc75cb5a719

And then the Preventor behavior 

https://github.com/user-attachments/assets/918a7546-ab8c-48b0-8f2f-42a929fc425f

I can change anything as needed.

Happy Modtoberfest!