### PR TITLE
Make using main-hand items not affect the rendering of off-hand items

### DIFF
--- a/src/main/java/com/dashomi/preventer/mixin/RenderHandItemMixin.java
+++ b/src/main/java/com/dashomi/preventer/mixin/RenderHandItemMixin.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.util.Hand;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -25,7 +26,7 @@ public class RenderHandItemMixin {
     )
     private void hideOffhandItem(LivingEntity entity, ItemStack stack, ModelTransformationMode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo callbackInfo) {
         if (!MinecraftClient.getInstance().options.getPerspective().isFirstPerson() ||
-                stack.isEmpty() || entity != MinecraftClient.getInstance().player || entity.isUsingItem()) return;
+                stack.isEmpty() || entity != MinecraftClient.getInstance().player || (entity.getActiveHand().equals(Hand.OFF_HAND) && entity.isUsingItem())) return;
 
         ClientPlayerEntity player = MinecraftClient.getInstance().player;
         if (player != null && player.getOffHandStack() != stack) return;


### PR DESCRIPTION
There currently is a bug that affects the hide shield and totem modules. Even when using main-hand items, the totem or shield becomes visible as if they were the items being used. This pr fixes that by checking if the used item is in the off-hand.