### PR TITLE
Add neutral mob attacking exception for piglins (#66)

### DIFF
--- a/src/main/java/com/dashomi/preventer/config/CreateModConfig.java
+++ b/src/main/java/com/dashomi/preventer/config/CreateModConfig.java
@@ -530,6 +530,14 @@ public class  CreateModConfig {
                         .build())
 
                 .addEntry(entryBuilder.startBooleanToggle(
+                                Text.translatable("config.preventer.neutralMobAttackingPiglinException"),
+                                config.neutralMobAttackingPiglinException)
+                        .setDefaultValue(false)
+                        .setTooltip(Text.translatable("tooltip.preventer.neutralMobAttackingPiglinException"))
+                        .setSaveConsumer(value -> config.neutralMobAttackingPiglinException = value)
+                        .build())
+
+                .addEntry(entryBuilder.startBooleanToggle(
                                 Text.translatable("config.preventer.preventChestSignEditing"),
                                 config.preventChestSignEditing)
                         .setDefaultValue(false)

--- a/src/main/java/com/dashomi/preventer/config/PreventerConfig.java
+++ b/src/main/java/com/dashomi/preventer/config/PreventerConfig.java
@@ -132,6 +132,7 @@ public class PreventerConfig implements ConfigData {
     public boolean preventNeutralMobAttacking = false;
     public boolean preventNeutralMobAttacking_msg = false;
     public boolean fullNeutralMobAttackingPrevention = false;
+    public boolean neutralMobAttackingPiglinException = false;
     public boolean preventDolphinAttacking = false;
     public boolean preventDolphinAttacking_msg = false;
 

--- a/src/main/java/com/dashomi/preventer/listeners/AttackEntityEvent.java
+++ b/src/main/java/com/dashomi/preventer/listeners/AttackEntityEvent.java
@@ -124,7 +124,10 @@ public class AttackEntityEvent {
                         return ActionResult.FAIL;
                     }
                 } else {
-                    if (isNeutralMob(entity)) {
+                    if (isNeutralMob(entity) && (!(entity instanceof PiglinEntity)
+                            || !PreventerClient.config.neutralMobAttackingPiglinException
+                            || PiglinBrain.wearsGoldArmor(playerEntity))) {
+
                         if (PreventerClient.config.preventNeutralMobAttacking_msg) {
                             playerEntity.sendMessage(Text.translatable("config.preventer.preventNeutralMobAttacking.text"), true);
                         }

--- a/src/main/resources/assets/preventer/lang/en_us.json
+++ b/src/main/resources/assets/preventer/lang/en_us.json
@@ -165,6 +165,8 @@
   "config.preventer.preventNeutralMobAttacking.text": "§4Neutral mob hitting prevented§4",
   "config.preventer.fullNeutralMobAttackingPrevention": "Full neutral mob hitting prevention",
   "tooltip.preventer.fullNeutralMobAttackingPrevention": "additionally prevents you from attacking spiders and endermen",
+  "config.preventer.neutralMobAttackingPiglinException": "Neutral mob piglin exception",
+  "tooltip.preventer.neutralMobAttackingPiglinException": "Allow hitting piglins if you're not wearing gold armor",
 
   "option.preventer.preventSuspiciousBlockBreaking": "Prevent suspicious block breaking",
   "tooltip.preventer.preventSuspiciousBlockBreaking": "Prevents you from breaking suspicious sand and gravel",


### PR DESCRIPTION
This adds an optional exception to the neutral mobs attack prevention module to allow attacking piglins when not wearing gold armor.