### PR TITLE
Rework hideShield and hideTotem into one option

### DIFF
--- a/src/main/java/com/dashomi/preventer/config/CreateModConfig.java
+++ b/src/main/java/com/dashomi/preventer/config/CreateModConfig.java
@@ -3,7 +3,11 @@ package com.dashomi.preventer.config;
 import me.shedaniel.clothconfig2.api.ConfigBuilder;
 import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.item.Items;
+import net.minecraft.registry.Registries;
 import net.minecraft.text.Text;
+
+import java.util.List;
 
 public class  CreateModConfig {
     public static Screen createConfigScreen(Screen parent) {
@@ -470,19 +474,25 @@ public class  CreateModConfig {
                 //        .build())
 
                 .addEntry(entryBuilder.startBooleanToggle(
-                                Text.translatable("option.preventer.hideShield"),
-                                config.hideShield)
+                                Text.translatable("option.preventer.hideOffhand"),
+                                config.hideOffhand)
                         .setDefaultValue(false)
-                        .setTooltip(Text.translatable("tooltip.preventer.hideShield"))
-                        .setSaveConsumer(value -> config.hideShield = value)
+                        .setSaveConsumer(value -> config.hideOffhand = value)
                         .build())
 
                 .addEntry(entryBuilder.startBooleanToggle(
-                                Text.translatable("option.preventer.hideTotem"),
-                                config.hideTotem)
-                        .setDefaultValue(false)
-                        .setTooltip(Text.translatable("tooltip.preventer.hideTotem"))
-                        .setSaveConsumer(value -> config.hideTotem = value)
+                                Text.translatable("option.preventer.unhideOffhandOnUse"),
+                                config.unhideOffhandOnUse)
+                        .setDefaultValue(true)
+                        .setTooltip(Text.translatable("tooltip.preventer.unhideOffhandOnUse"))
+                        .setSaveConsumer(value -> config.unhideOffhandOnUse = value)
+                        .build())
+
+                .addEntry(entryBuilder.startStrList(
+                                Text.translatable("option.preventer.hiddenOffhandItems"),
+                                config.hiddenOffhandItems)
+                        .setDefaultValue(List.of(Registries.ITEM.getId(Items.TOTEM_OF_UNDYING).toString(), Registries.ITEM.getId(Items.SHIELD).toString()))
+                        .setSaveConsumer(value -> config.hiddenOffhandItems = value)
                         .build())
 
                 .addEntry(entryBuilder.startTextDescription(

--- a/src/main/java/com/dashomi/preventer/config/PreventerConfig.java
+++ b/src/main/java/com/dashomi/preventer/config/PreventerConfig.java
@@ -3,12 +3,17 @@ package com.dashomi.preventer.config;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
+import net.minecraft.item.Items;
+import net.minecraft.registry.Registries;
+
+import java.util.List;
 
 @Config(name = "preventer")
 public class PreventerConfig implements ConfigData {
     public static PreventerConfig get() {
         return AutoConfig.getConfigHolder(PreventerConfig.class).getConfig();
     }
+
     public boolean welcomeMessage = true;
 
     public static void save() {
@@ -145,7 +150,8 @@ public class PreventerConfig implements ConfigData {
     public boolean preventRenamedItemDropping_msg = false;
     //public boolean preventEnchantedItemBurning = false;
     //public boolean preventEnchantedItemBurning_msg = false;
-    public boolean hideShield = false;
-    public boolean hideTotem = false;
+    public boolean hideOffhand = false;
+    public boolean unhideOffhandOnUse = true;
+    public List<String> hiddenOffhandItems = List.of(Registries.ITEM.getId(Items.TOTEM_OF_UNDYING).toString(), Registries.ITEM.getId(Items.SHIELD).toString());
     public boolean notifyToggledOff = true;
 }

--- a/src/main/java/com/dashomi/preventer/mixin/RenderHandItemMixin.java
+++ b/src/main/java/com/dashomi/preventer/mixin/RenderHandItemMixin.java
@@ -10,7 +10,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
+import net.minecraft.registry.Registries;
 import net.minecraft.util.Hand;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -25,18 +25,18 @@ public class RenderHandItemMixin {
             cancellable = true
     )
     private void hideOffhandItem(LivingEntity entity, ItemStack stack, ModelTransformationMode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, CallbackInfo callbackInfo) {
+        if (!PreventerClient.config.hideOffhand) return;
+
         if (!MinecraftClient.getInstance().options.getPerspective().isFirstPerson() ||
-                stack.isEmpty() || entity != MinecraftClient.getInstance().player || (entity.getActiveHand().equals(Hand.OFF_HAND) && entity.isUsingItem())) return;
+                stack.isEmpty() || entity != MinecraftClient.getInstance().player) return;
+
+        if (PreventerClient.config.unhideOffhandOnUse && (entity.getActiveHand().equals(Hand.OFF_HAND) && entity.isUsingItem())) return;
 
         ClientPlayerEntity player = MinecraftClient.getInstance().player;
         if (player != null && player.getOffHandStack() != stack) return;
         Item handItem = stack.getItem();
 
-        if (handItem == Items.SHIELD && PreventerClient.config.hideShield) {
-            callbackInfo.cancel();
-        }
-
-        if (handItem == Items.TOTEM_OF_UNDYING && PreventerClient.config.hideTotem) {
+        if (PreventerClient.config.hiddenOffhandItems.contains(Registries.ITEM.getId(handItem).toString())) {
             callbackInfo.cancel();
         }
     }

--- a/src/main/resources/assets/preventer/lang/en_us.json
+++ b/src/main/resources/assets/preventer/lang/en_us.json
@@ -254,9 +254,8 @@
   "tooltip.preventer.preventImmatureAmethystBreaking": "Prevents you from breaking immature amethyst crystals",
   "config.preventer.preventImmatureAmethystBreaking.text": "§4Immature amethyst breaking prevented§4",
 
-  "option.preventer.hideTotem": "Hide totem",
-  "tooltip.preventer.hideTotem": "Hides totems of undying in the offhand",
-
-  "option.preventer.hideShield": "Hide shield",
-  "tooltip.preventer.hideShield": "Hides shields in the offhand"
+  "option.preventer.hideOffhand": "Hide specified offhand items",
+  "option.preventer.unhideOffhandOnUse": "Unhide offhand item on use",
+  "tooltip.preventer.unhideOffhandOnUse": "Unhides offhand items while they are being used. Depends on the option above.",
+  "option.preventer.hiddenOffhandItems": "Offhand items to hide"
 }


### PR DESCRIPTION
Hi, it's me again

I've reworked hideShield and hideTotem into one option, hideOffhand, with two sub-options. Now, users can configure if they want the item to be unhidden when in use and which items to hide (totems and shields by default).